### PR TITLE
Fix Bedwars presence badge

### DIFF
--- a/src/hooks/useRobloxStatus.ts
+++ b/src/hooks/useRobloxStatus.ts
@@ -96,7 +96,9 @@ export function useRobloxStatus(userId: number) {
           if (mounted) {
             setStatus({
               isOnline: data.isOnline,
-              inBedwars: data.placeId === BEDWARS_PLACE_ID,
+              inBedwars: typeof data.inBedwars === 'boolean'
+                ? data.inBedwars
+                : data.placeId === BEDWARS_PLACE_ID,
               lastUpdated: data.lastUpdated || Date.now(),
               username: data.username || `User ${userId}`,
               placeId: data.placeId

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -23,13 +23,14 @@ interface UserStatus {
   username: string;
   isOnline: boolean;
   inBedwars: boolean;
+  placeId: string | null;
   lastUpdated: number;
 }
 
 const CACHE_DURATION = 60; // Cache for 1 minute
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY = 1000;
-const BEDWARS_UNIVERSE_ID = '2535881226';
+const BEDWARS_PLACE_ID = '6872265039';
 const REQUEST_TIMEOUT = 15000; // Increased to 15 seconds
 
 const statusCache = new Map<number, UserStatus>();
@@ -141,7 +142,11 @@ async function getUserStatus(userId: number): Promise<UserStatus> {
       userId,
       username,
       isOnline: presence ? presence.userPresenceType !== 0 : false,
-      inBedwars: presence ? presence.universeId === BEDWARS_UNIVERSE_ID : false,
+      inBedwars: presence
+        ? presence.placeId === BEDWARS_PLACE_ID ||
+          presence.rootPlaceId === BEDWARS_PLACE_ID
+        : false,
+      placeId: presence ? presence.placeId : null,
       lastUpdated: Date.now()
     };
 


### PR DESCRIPTION
## Summary
- add placeId to `UserStatus` and check Bedwars presence using the place ID
- carry `placeId` back to the hook and honor server-provided `inBedwars`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841541d5920832dbe76493c454f6a4f