### PR TITLE
Fix Bedwars presence badge

### DIFF
--- a/src/hooks/useRobloxStatus.ts
+++ b/src/hooks/useRobloxStatus.ts
@@ -7,6 +7,7 @@ interface RobloxStatus {
   lastUpdated: number;
   username: string;
   placeId?: string;
+  universeId?: string;
 }
 
 export function useRobloxStatus(userId: number) {
@@ -17,6 +18,7 @@ export function useRobloxStatus(userId: number) {
   const MAX_RETRIES = 3;
   const RETRY_DELAY = 2000;
   const BEDWARS_PLACE_ID = '6872265039';
+  const BEDWARS_UNIVERSE_ID = '2619619496';
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -96,10 +98,14 @@ export function useRobloxStatus(userId: number) {
           if (mounted) {
             setStatus({
               isOnline: data.isOnline,
-              inBedwars: data.placeId === BEDWARS_PLACE_ID,
+              inBedwars: typeof data.inBedwars === 'boolean'
+                ? data.inBedwars
+                : data.placeId === BEDWARS_PLACE_ID ||
+                  data.universeId === BEDWARS_UNIVERSE_ID,
               lastUpdated: data.lastUpdated || Date.now(),
               username: data.username || `User ${userId}`,
-              placeId: data.placeId
+              placeId: data.placeId,
+              universeId: data.universeId
             });
             setError(null);
             setRetryCount(0);

--- a/src/pages/PlayersPage.tsx
+++ b/src/pages/PlayersPage.tsx
@@ -51,6 +51,8 @@ export default function PlayersPage() {
                       inBedwars: data.inBedwars,
                       username: data.username,
                       lastUpdated: data.lastUpdated,
+                      placeId: data.placeId,
+                      universeId: data.universeId,
                     },
                   };
                 }

--- a/src/types/players.ts
+++ b/src/types/players.ts
@@ -23,6 +23,8 @@ export interface PlayerAccount {
     inBedwars: boolean;
     username: string;
     lastUpdated: number;
+    placeId?: string | null;
+    universeId?: string | null;
   };
 }
 

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -23,13 +23,16 @@ interface UserStatus {
   username: string;
   isOnline: boolean;
   inBedwars: boolean;
+  placeId: string | null;
+  universeId: string | null;
   lastUpdated: number;
 }
 
 const CACHE_DURATION = 60; // Cache for 1 minute
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY = 1000;
-const BEDWARS_UNIVERSE_ID = '2535881226';
+const BEDWARS_PLACE_ID = '6872265039';
+const BEDWARS_UNIVERSE_ID = '2619619496';
 const REQUEST_TIMEOUT = 15000; // Increased to 15 seconds
 
 const statusCache = new Map<number, UserStatus>();
@@ -141,7 +144,13 @@ async function getUserStatus(userId: number): Promise<UserStatus> {
       userId,
       username,
       isOnline: presence ? presence.userPresenceType !== 0 : false,
-      inBedwars: presence ? presence.universeId === BEDWARS_UNIVERSE_ID : false,
+      inBedwars: presence
+        ? presence.placeId === BEDWARS_PLACE_ID ||
+          presence.rootPlaceId === BEDWARS_PLACE_ID ||
+          presence.universeId === BEDWARS_UNIVERSE_ID
+        : false,
+      placeId: presence ? presence.placeId : null,
+      universeId: presence ? presence.universeId : null,
       lastUpdated: Date.now()
     };
 


### PR DESCRIPTION
## Summary
- check player presence using the Bedwars universe ID in the server function
- expose `universeId` to the frontend and include it in status objects
- include placeId and universeId when fetching account statuses

## Testing
- `npm run lint` *(fails: 42 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6841541d5920832dbe76493c454f6a4f