### PR TITLE
Add Bedwars presence check with Roblox cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # BAN-SYSTEM-3.0-WEBSITE-CODEX
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/TheRacBW/BAN-SYSTEM-3.0-WEBSITE-CODEX)
+
+## Environment Variables
+
+The `roblox-status` function uses the Roblox Presence API and requires a `.ROBLOSECURITY` cookie for detailed presence information. Set the cookie in your deployment environment using the `ROBLOX_COOKIE` variable:
+
+```bash
+export ROBLOX_COOKIE=your_roblox_cookie_here
+```

--- a/src/hooks/useRobloxStatus.ts
+++ b/src/hooks/useRobloxStatus.ts
@@ -7,6 +7,7 @@ interface RobloxStatus {
   lastUpdated: number;
   username: string;
   placeId?: string;
+  universeId?: string;
 }
 
 export function useRobloxStatus(userId: number) {
@@ -17,6 +18,7 @@ export function useRobloxStatus(userId: number) {
   const MAX_RETRIES = 3;
   const RETRY_DELAY = 2000;
   const BEDWARS_PLACE_ID = '6872265039';
+  const BEDWARS_UNIVERSE_ID = '2619619496';
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -98,10 +100,12 @@ export function useRobloxStatus(userId: number) {
               isOnline: data.isOnline,
               inBedwars: typeof data.inBedwars === 'boolean'
                 ? data.inBedwars
-                : data.placeId === BEDWARS_PLACE_ID,
+                : data.placeId === BEDWARS_PLACE_ID ||
+                  data.universeId === BEDWARS_UNIVERSE_ID,
               lastUpdated: data.lastUpdated || Date.now(),
               username: data.username || `User ${userId}`,
-              placeId: data.placeId
+              placeId: data.placeId,
+              universeId: data.universeId
             });
             setError(null);
             setRetryCount(0);


### PR DESCRIPTION
## Summary
- use `ROBLOX_COOKIE` for Roblox Presence API
- detect Bedwars by universeId or placeId
- expose universeId in status API
- handle universeId in `useRobloxStatus`
- document new environment variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415b162808832d88a0590f35c4cca7