### PR TITLE
Add Roblox cookie admin option and kit search

### DIFF
--- a/src/components/RobloxCookiePanel.tsx
+++ b/src/components/RobloxCookiePanel.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { AlertCircle, Save } from 'lucide-react';
+
+const RobloxCookiePanel: React.FC = () => {
+  const [cookie, setCookie] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCookie = async () => {
+      try {
+        const { data } = await supabase
+          .from('roblox_settings')
+          .select('cookie')
+          .eq('id', 'global')
+          .single();
+        if (data?.cookie) setCookie(data.cookie);
+      } catch (err) {
+        console.error('Error fetching cookie:', err);
+        setError('Failed to load cookie');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCookie();
+  }, []);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    try {
+      const { error } = await supabase
+        .from('roblox_settings')
+        .upsert({ id: 'global', cookie, updated_at: new Date().toISOString() });
+      if (error) throw error;
+      setSuccess('Cookie saved successfully');
+      setTimeout(() => setSuccess(null), 3000);
+    } catch (err) {
+      console.error('Error saving cookie:', err);
+      setError('Failed to save cookie');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-24">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-2">Roblox Cookie</h2>
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        Provide your .ROBLOSECURITY cookie to enable online and Bedwars detection.
+      </p>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded flex items-center">
+          <AlertCircle className="mr-2" size={18} />
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="mb-4 p-3 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded">
+          {success}
+        </div>
+      )}
+
+      <form onSubmit={handleSave} className="space-y-4">
+        <textarea
+          value={cookie}
+          onChange={(e) => setCookie(e.target.value)}
+          className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600"
+          rows={3}
+          placeholder="Paste .ROBLOSECURITY cookie here"
+        />
+        <button type="submit" className="btn btn-primary flex items-center gap-2">
+          <Save size={18} />
+          Save Cookie
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default RobloxCookiePanel;

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -6,6 +6,7 @@ import { Shield, Users, Swords, Settings, Plus, X, Edit2 } from 'lucide-react';
 import { Kit, KitType } from '../types';
 import KitCard from '../components/KitCard';
 import AdSettingsPanel from '../components/AdSettingsPanel';
+import RobloxCookiePanel from '../components/RobloxCookiePanel';
 
 interface AdminStats {
   totalUsers: number;
@@ -26,6 +27,7 @@ const AdminPage = () => {
   const [showKitModal, setShowKitModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [kits, setKits] = useState<Kit[]>([]);
+  const [kitSearch, setKitSearch] = useState('');
   const [newKit, setNewKit] = useState<Partial<Kit>>({
     name: '',
     imageUrl: '',
@@ -190,6 +192,10 @@ const AdminPage = () => {
     setShowEditModal(true);
   };
 
+  const filteredKits = kits.filter(k =>
+    k.name.toLowerCase().includes(kitSearch.toLowerCase())
+  );
+
   if (!user || !isAdmin) {
     return <Navigate to="/" replace />;
   }
@@ -256,6 +262,10 @@ const AdminPage = () => {
 
       <div className="space-y-8">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+          <RobloxCookiePanel />
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
           <AdSettingsPanel />
         </div>
 
@@ -283,8 +293,18 @@ const AdminPage = () => {
             </div>
           )}
 
+          <div className="mb-4">
+            <input
+              type="text"
+              value={kitSearch}
+              onChange={(e) => setKitSearch(e.target.value)}
+              placeholder="Search kits..."
+              className="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600"
+            />
+          </div>
+
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-            {kits.map(kit => (
+            {filteredKits.map(kit => (
               <div key={kit.id} className="relative group">
                 <KitCard kit={kit} />
                 <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/supabase/migrations/20250605120000_feral_cookie.sql
+++ b/supabase/migrations/20250605120000_feral_cookie.sql
@@ -1,0 +1,50 @@
+/*
+  # Add Roblox cookie settings
+
+  1. New Tables
+    - roblox_settings
+      - id (text, primary key)
+      - cookie (text)
+      - updated_at (timestamp)
+
+  2. Security
+    - Only admins can modify cookie
+    - Anyone can read cookie (for functions)
+*/
+
+CREATE TABLE roblox_settings (
+  id text PRIMARY KEY,
+  cookie text,
+  updated_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE roblox_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can read roblox settings"
+  ON roblox_settings
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Only admins can modify roblox settings"
+  ON roblox_settings
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE users.id = auth.uid()
+      AND users.is_admin = true
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE users.id = auth.uid()
+      AND users.is_admin = true
+    )
+  );
+
+INSERT INTO roblox_settings (id, cookie)
+VALUES ('global', '')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- enable storing `.ROBLOSECURITY` cookie in Supabase
- add panel on Admin page to manage Roblox cookie
- expose cookie to status function
- allow searching kits in kit management
- database migration for `roblox_settings`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68415ee55d10832da444eacc1969296b