### PR TITLE
Add BedWars icon detection using place/universe IDs

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -25,6 +25,8 @@ import {
 
 const BEDWARS_ICON_URL =
   'https://cdn2.steamgriddb.com/icon/3ad9ecf4b4a26b7671e09283f001d626.png';
+const BEDWARS_PLACE_ID = '6872265039';
+const BEDWARS_UNIVERSE_ID = '2619619496';
 
 interface PlayerCardProps {
   player: Player;
@@ -419,7 +421,9 @@ function PlayerCard({ player, onDelete, isAdmin }: PlayerCardProps) {
                     title="Rank unknown"
                   />
                 )}
-                {account.status?.inBedwars && (
+                {(account.status?.inBedwars ||
+                  account.status?.placeId === BEDWARS_PLACE_ID ||
+                  account.status?.universeId === BEDWARS_UNIVERSE_ID) && (
                   <img
                     src={BEDWARS_ICON_URL}
                     alt="BedWars"
@@ -542,7 +546,9 @@ function PlayerCard({ player, onDelete, isAdmin }: PlayerCardProps) {
                         <span className="text-sm">Rank unknown</span>
                       </div>
                     )}
-                    {account.status?.inBedwars && (
+                    {(account.status?.inBedwars ||
+                      account.status?.placeId === BEDWARS_PLACE_ID ||
+                      account.status?.universeId === BEDWARS_UNIVERSE_ID) && (
                       <img
                         src={BEDWARS_ICON_URL}
                         alt="BedWars"

--- a/src/components/RobloxStatus.tsx
+++ b/src/components/RobloxStatus.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react';
 import { useRobloxStatus } from '../hooks/useRobloxStatus';
 import { CircleDot, CircleSlash, Gamepad2 } from 'lucide-react';
 
+const BEDWARS_PLACE_ID = '6872265039';
+const BEDWARS_UNIVERSE_ID = '2619619496';
+
 interface RobloxStatusProps {
   userId: number;
 }
@@ -42,7 +45,9 @@ export default function RobloxStatus({ userId }: RobloxStatusProps) {
           </span>
         </div>
         
-        {status.inBedwars && (
+        {(status.inBedwars ||
+          status.placeId === BEDWARS_PLACE_ID ||
+          status.universeId === BEDWARS_UNIVERSE_ID) && (
           <div className="flex items-center gap-1 text-blue-600 dark:text-blue-400">
             <Gamepad2 size={12} />
             <span>In Bedwars</span>

--- a/src/pages/PlayersPage.tsx
+++ b/src/pages/PlayersPage.tsx
@@ -6,6 +6,9 @@ import { Player, SortOption, RANK_VALUES } from '../types/players';
 import { Plus, Search, Users, Gamepad2, ArrowUpDown } from 'lucide-react';
 import PlayerCard from '../components/PlayerCard';
 
+const BEDWARS_PLACE_ID = '6872265039';
+const BEDWARS_UNIVERSE_ID = '2619619496';
+
 export default function PlayersPage() {
   const navigate = useNavigate();
   const { user, isAdmin } = useAuth();
@@ -49,6 +52,8 @@ export default function PlayersPage() {
                     status: {
                       isOnline: data.isOnline,
                       inBedwars: data.inBedwars,
+                      placeId: data.placeId,
+                      universeId: data.universeId,
                       username: data.username,
                       lastUpdated: data.lastUpdated,
                     },
@@ -208,9 +213,13 @@ export default function PlayersPage() {
       account.status?.isOnline
     );
 
-    const hasInBedwarsAccount = !showInBedwarsOnly || player.accounts?.some(account => 
-      account.status?.inBedwars
-    );
+    const hasInBedwarsAccount =
+      !showInBedwarsOnly ||
+      player.accounts?.some(account =>
+        account.status?.inBedwars ||
+        account.status?.placeId === BEDWARS_PLACE_ID ||
+        account.status?.universeId === BEDWARS_UNIVERSE_ID
+      );
 
     return matchesSearch && hasOnlineAccount && hasInBedwarsAccount;
   });

--- a/src/types/players.ts
+++ b/src/types/players.ts
@@ -21,6 +21,8 @@ export interface PlayerAccount {
   status?: {
     isOnline: boolean;
     inBedwars: boolean;
+    placeId?: string;
+    universeId?: string;
     username: string;
     lastUpdated: number;
   };


### PR DESCRIPTION
## Summary
- extend player status type with placeId and universeId
- fetch placeId and universeId for account statuses
- support BedWars presence check via placeId or universeId
- filter players by BedWars presence

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841666a20f8832dbab203171e3ebe9e