### PR TITLE
Switch Roblox IDs to numbers

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -25,8 +25,8 @@ import {
 
 const BEDWARS_ICON_URL =
   'https://cdn2.steamgriddb.com/icon/3ad9ecf4b4a26b7671e09283f001d626.png';
-const BEDWARS_PLACE_ID = '6872265039';
-const BEDWARS_UNIVERSE_ID = '2619619496';
+const BEDWARS_PLACE_ID = 6872265039;
+const BEDWARS_UNIVERSE_ID = 2619619496;
 
 interface PlayerCardProps {
   player: Player;

--- a/src/components/RobloxStatus.tsx
+++ b/src/components/RobloxStatus.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect } from 'react';
 import { useRobloxStatus } from '../hooks/useRobloxStatus';
 import { CircleDot, CircleSlash, Gamepad2 } from 'lucide-react';
 
-const BEDWARS_PLACE_ID = '6872265039';
-const BEDWARS_UNIVERSE_ID = '2619619496';
+const BEDWARS_PLACE_ID = 6872265039;
+const BEDWARS_UNIVERSE_ID = 2619619496;
 
 interface RobloxStatusProps {
   userId: number;

--- a/src/hooks/useRobloxStatus.ts
+++ b/src/hooks/useRobloxStatus.ts
@@ -6,8 +6,8 @@ interface RobloxStatus {
   inBedwars: boolean;
   lastUpdated: number;
   username: string;
-  placeId?: string;
-  universeId?: string;
+  placeId?: number;
+  universeId?: number;
 }
 
 export function useRobloxStatus(userId: number) {
@@ -17,8 +17,8 @@ export function useRobloxStatus(userId: number) {
   const [retryCount, setRetryCount] = useState(0);
   const MAX_RETRIES = 3;
   const RETRY_DELAY = 2000;
-  const BEDWARS_PLACE_ID = '6872265039';
-  const BEDWARS_UNIVERSE_ID = '2619619496';
+  const BEDWARS_PLACE_ID = 6872265039;
+  const BEDWARS_UNIVERSE_ID = 2619619496;
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;

--- a/src/pages/PlayersPage.tsx
+++ b/src/pages/PlayersPage.tsx
@@ -6,8 +6,8 @@ import { Player, SortOption, RANK_VALUES } from '../types/players';
 import { Plus, Search, Users, Gamepad2, ArrowUpDown } from 'lucide-react';
 import PlayerCard from '../components/PlayerCard';
 
-const BEDWARS_PLACE_ID = '6872265039';
-const BEDWARS_UNIVERSE_ID = '2619619496';
+const BEDWARS_PLACE_ID = 6872265039;
+const BEDWARS_UNIVERSE_ID = 2619619496;
 
 export default function PlayersPage() {
   const navigate = useNavigate();

--- a/src/types/players.ts
+++ b/src/types/players.ts
@@ -21,8 +21,8 @@ export interface PlayerAccount {
   status?: {
     isOnline: boolean;
     inBedwars: boolean;
-    placeId?: string;
-    universeId?: string;
+    placeId?: number;
+    universeId?: number;
     username: string;
     lastUpdated: number;
   };

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -9,10 +9,10 @@ const corsHeaders = {
 interface UserPresence {
   userPresenceType: number;
   lastLocation: string;
-  placeId: string | null;
-  rootPlaceId: string | null;
+  placeId: number | null;
+  rootPlaceId: number | null;
   gameId: string | null;
-  universeId: string | null;
+  universeId: number | null;
   userId: number;
   lastOnline: string;
 }
@@ -22,16 +22,16 @@ interface UserStatus {
   username: string;
   isOnline: boolean;
   inBedwars: boolean;
-  placeId: string | null;
-  universeId: string | null;
+  placeId: number | null;
+  universeId: number | null;
   lastUpdated: number;
 }
 
 const CACHE_DURATION = 60; // Cache for 1 minute
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY = 1000;
-const BEDWARS_PLACE_ID = '6872265039';
-const BEDWARS_UNIVERSE_ID = '2619619496';
+const BEDWARS_PLACE_ID = 6872265039;
+const BEDWARS_UNIVERSE_ID = 2619619496;
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
@@ -166,12 +166,12 @@ async function getUserStatus(userId: number): Promise<UserStatus> {
       username,
       isOnline: presence ? [1, 2].includes(presence.userPresenceType) : false,
       inBedwars: presence
-        ? presence.placeId === BEDWARS_PLACE_ID ||
-          presence.rootPlaceId === BEDWARS_PLACE_ID ||
-          presence.universeId === BEDWARS_UNIVERSE_ID
+        ? Number(presence.placeId) === BEDWARS_PLACE_ID ||
+          Number(presence.rootPlaceId) === BEDWARS_PLACE_ID ||
+          Number(presence.universeId) === BEDWARS_UNIVERSE_ID
         : false,
-      placeId: presence ? presence.placeId : null,
-      universeId: presence ? presence.universeId : null,
+      placeId: presence ? Number(presence.placeId) : null,
+      universeId: presence ? Number(presence.universeId) : null,
       lastUpdated: Date.now()
     };
 


### PR DESCRIPTION
## Summary
- treat placeId and universeId as numbers
- convert ID constants to numeric values
- keep numeric equality in edge function and frontend

## Testing
- `npm run lint` *(fails: 42 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684169b3b180832dbfa81449d18673fb