### PR TITLE
Centralize bedwars constants

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -23,10 +23,10 @@ import {
   Star
 } from 'lucide-react';
 
+import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../constants/bedwars';
+
 const BEDWARS_ICON_URL =
   'https://cdn2.steamgriddb.com/icon/3ad9ecf4b4a26b7671e09283f001d626.png';
-const BEDWARS_PLACE_ID = '6872265039';
-const BEDWARS_UNIVERSE_ID = '2619619496';
 
 interface PlayerCardProps {
   player: Player;

--- a/src/components/RobloxStatus.tsx
+++ b/src/components/RobloxStatus.tsx
@@ -1,9 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useRobloxStatus } from '../hooks/useRobloxStatus';
 import { CircleDot, CircleSlash, Gamepad2 } from 'lucide-react';
-
-const BEDWARS_PLACE_ID = '6872265039';
-const BEDWARS_UNIVERSE_ID = '2619619496';
+import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../constants/bedwars';
 
 interface RobloxStatusProps {
   userId: number;

--- a/src/constants/bedwars.ts
+++ b/src/constants/bedwars.ts
@@ -1,0 +1,2 @@
+export const BEDWARS_PLACE_ID = '6872265039';
+export const BEDWARS_UNIVERSE_ID = '2619619496';

--- a/src/hooks/useRobloxStatus.ts
+++ b/src/hooks/useRobloxStatus.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../constants/bedwars';
 
 interface RobloxStatus {
   isOnline: boolean;
@@ -17,8 +18,6 @@ export function useRobloxStatus(userId: number) {
   const [retryCount, setRetryCount] = useState(0);
   const MAX_RETRIES = 3;
   const RETRY_DELAY = 2000;
-  const BEDWARS_PLACE_ID = '6872265039';
-  const BEDWARS_UNIVERSE_ID = '2619619496';
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;

--- a/src/pages/PlayersPage.tsx
+++ b/src/pages/PlayersPage.tsx
@@ -5,9 +5,7 @@ import { supabase } from '../lib/supabase';
 import { Player, SortOption, RANK_VALUES } from '../types/players';
 import { Plus, Search, Users, Gamepad2, ArrowUpDown } from 'lucide-react';
 import PlayerCard from '../components/PlayerCard';
-
-const BEDWARS_PLACE_ID = '6872265039';
-const BEDWARS_UNIVERSE_ID = '2619619496';
+import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../constants/bedwars';
 
 export default function PlayersPage() {
   const navigate = useNavigate();

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -30,8 +30,7 @@ interface UserStatus {
 const CACHE_DURATION = 60; // Cache for 1 minute
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY = 1000;
-const BEDWARS_PLACE_ID = '6872265039';
-const BEDWARS_UNIVERSE_ID = '2619619496';
+import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../../src/constants/bedwars.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -30,7 +30,7 @@ interface UserStatus {
 const CACHE_DURATION = 60; // Cache for 1 minute
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY = 1000;
-import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../../src/constants/bedwars.ts';
+import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../../src/constants/bedwars';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';


### PR DESCRIPTION
## Summary
- centralize Bedwars IDs in `src/constants/bedwars.ts`
- reuse shared constants across the codebase

## Testing
- `npm run lint` *(fails: 42 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684169b81e7c832db288b2265f6f9b83