### PR TITLE
Add rootPlaceId to status

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -423,6 +423,7 @@ function PlayerCard({ player, onDelete, isAdmin }: PlayerCardProps) {
                 )}
                 {(account.status?.inBedwars ||
                   account.status?.placeId === BEDWARS_PLACE_ID ||
+                  account.status?.rootPlaceId === BEDWARS_PLACE_ID ||
                   account.status?.universeId === BEDWARS_UNIVERSE_ID) && (
                   <img
                     src={BEDWARS_ICON_URL}
@@ -548,6 +549,7 @@ function PlayerCard({ player, onDelete, isAdmin }: PlayerCardProps) {
                     )}
                     {(account.status?.inBedwars ||
                       account.status?.placeId === BEDWARS_PLACE_ID ||
+                      account.status?.rootPlaceId === BEDWARS_PLACE_ID ||
                       account.status?.universeId === BEDWARS_UNIVERSE_ID) && (
                       <img
                         src={BEDWARS_ICON_URL}

--- a/src/components/RobloxStatus.tsx
+++ b/src/components/RobloxStatus.tsx
@@ -47,6 +47,7 @@ export default function RobloxStatus({ userId }: RobloxStatusProps) {
         
         {(status.inBedwars ||
           status.placeId === BEDWARS_PLACE_ID ||
+          status.rootPlaceId === BEDWARS_PLACE_ID ||
           status.universeId === BEDWARS_UNIVERSE_ID) && (
           <div className="flex items-center gap-1 text-blue-600 dark:text-blue-400">
             <Gamepad2 size={12} />

--- a/src/hooks/useRobloxStatus.ts
+++ b/src/hooks/useRobloxStatus.ts
@@ -7,6 +7,7 @@ interface RobloxStatus {
   lastUpdated: number;
   username: string;
   placeId?: string;
+  rootPlaceId?: string;
   universeId?: string;
 }
 
@@ -101,10 +102,12 @@ export function useRobloxStatus(userId: number) {
               inBedwars: typeof data.inBedwars === 'boolean'
                 ? data.inBedwars
                 : data.placeId === BEDWARS_PLACE_ID ||
+                  data.rootPlaceId === BEDWARS_PLACE_ID ||
                   data.universeId === BEDWARS_UNIVERSE_ID,
               lastUpdated: data.lastUpdated || Date.now(),
               username: data.username || `User ${userId}`,
               placeId: data.placeId,
+              rootPlaceId: data.rootPlaceId,
               universeId: data.universeId
             });
             setError(null);

--- a/src/pages/PlayersPage.tsx
+++ b/src/pages/PlayersPage.tsx
@@ -47,17 +47,18 @@ export default function PlayersPage() {
                 });
                 if (res.ok) {
                   const data = await res.json();
-                  return {
-                    ...acc,
-                    status: {
-                      isOnline: data.isOnline,
-                      inBedwars: data.inBedwars,
-                      placeId: data.placeId,
-                      universeId: data.universeId,
-                      username: data.username,
-                      lastUpdated: data.lastUpdated,
-                    },
-                  };
+                    return {
+                      ...acc,
+                      status: {
+                        isOnline: data.isOnline,
+                        inBedwars: data.inBedwars,
+                        placeId: data.placeId,
+                        rootPlaceId: data.rootPlaceId,
+                        universeId: data.universeId,
+                        username: data.username,
+                        lastUpdated: data.lastUpdated,
+                      },
+                    };
                 }
               } catch (err) {
                 console.error('Status fetch error', err);
@@ -213,13 +214,14 @@ export default function PlayersPage() {
       account.status?.isOnline
     );
 
-    const hasInBedwarsAccount =
-      !showInBedwarsOnly ||
-      player.accounts?.some(account =>
-        account.status?.inBedwars ||
-        account.status?.placeId === BEDWARS_PLACE_ID ||
-        account.status?.universeId === BEDWARS_UNIVERSE_ID
-      );
+      const hasInBedwarsAccount =
+        !showInBedwarsOnly ||
+        player.accounts?.some(account =>
+          account.status?.inBedwars ||
+          account.status?.placeId === BEDWARS_PLACE_ID ||
+          account.status?.rootPlaceId === BEDWARS_PLACE_ID ||
+          account.status?.universeId === BEDWARS_UNIVERSE_ID
+        );
 
     return matchesSearch && hasOnlineAccount && hasInBedwarsAccount;
   });

--- a/src/types/players.ts
+++ b/src/types/players.ts
@@ -22,6 +22,7 @@ export interface PlayerAccount {
     isOnline: boolean;
     inBedwars: boolean;
     placeId?: string;
+    rootPlaceId?: string;
     universeId?: string;
     username: string;
     lastUpdated: number;

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -23,6 +23,7 @@ interface UserStatus {
   isOnline: boolean;
   inBedwars: boolean;
   placeId: string | null;
+  rootPlaceId: string | null;
   universeId: string | null;
   lastUpdated: number;
 }
@@ -171,6 +172,7 @@ async function getUserStatus(userId: number): Promise<UserStatus> {
           presence.universeId === BEDWARS_UNIVERSE_ID
         : false,
       placeId: presence ? presence.placeId : null,
+      rootPlaceId: presence ? presence.rootPlaceId : null,
       universeId: presence ? presence.universeId : null,
       lastUpdated: Date.now()
     };


### PR DESCRIPTION
## Summary
- include `rootPlaceId` in roblox-status function response
- extend PlayerAccount and hook types with `rootPlaceId`
- use `rootPlaceId` when displaying BedWars status

## Testing
- `npm ci`
- `npm run lint` *(fails: cannot resolve '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684169c5faa8832d85ea446c165bcc89