### PR TITLE
Add cookie warning log

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## Environment Variables
 
-The `roblox-status` function uses the Roblox Presence API and requires a `.ROBLOSECURITY` cookie for detailed presence information. Set the cookie in your deployment environment using the `ROBLOX_COOKIE` variable:
+The `roblox-status` function uses the Roblox Presence API and requires a `.ROBLOSECURITY` cookie for detailed presence information. The cookie can be provided either via the `ROBLOX_COOKIE` environment variable or stored in the `roblox_settings` table (row with `id` set to `global`). If both are present, the table value is used.
+
+Set the cookie in your deployment environment using the `ROBLOX_COOKIE` variable:
 
 ```bash
 export ROBLOX_COOKIE=your_roblox_cookie_here

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -161,6 +161,16 @@ async function getUserStatus(userId: number): Promise<UserStatus> {
       throw new Error(`Unable to find Roblox user with ID ${userId}`);
     }
 
+    if (
+      presence &&
+      [1, 2].includes(presence.userPresenceType) &&
+      (!presence.placeId || !presence.universeId)
+    ) {
+      console.warn(
+        'Presence API response lacked placeId or universeId; ROBLOX_COOKIE may be invalid.'
+      );
+    }
+
     const status: UserStatus = {
       userId,
       username,


### PR DESCRIPTION
## Summary
- clarify how the `.ROBLOSECURITY` cookie can be provided
- warn when Presence API data lacks `placeId` or `universeId`

## Testing
- `npm run lint` *(fails: 42 errors, 11 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684169ccde70832d8a7dd79884ba0834