### PR TITLE
Add rootPlaceId to player status

### DIFF
--- a/src/pages/PlayersPage.tsx
+++ b/src/pages/PlayersPage.tsx
@@ -51,6 +51,7 @@ export default function PlayersPage() {
                       isOnline: data.isOnline,
                       inBedwars: data.inBedwars,
                       placeId: data.placeId,
+                      rootPlaceId: data.rootPlaceId,
                       universeId: data.universeId,
                       username: data.username,
                       lastUpdated: data.lastUpdated,


### PR DESCRIPTION
## Summary
- include `rootPlaceId` when fetching account status on Players page

## Testing
- `npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68417b708f68832dba7fed94aa4cb0fb