### PR TITLE
Fix presence API headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 The `roblox-status` function uses the Roblox Presence API and requires a `.ROBLOSECURITY` cookie for detailed presence information. The cookie can be provided either via the `ROBLOX_COOKIE` environment variable or stored in the `roblox_settings` table (row with `id` set to `global`). If both are present, the table value is used.
 
+All Roblox API requests are sent with the headers `User-Agent: Roblox/WinInet` and `Referer: https://www.roblox.com/` to mimic the official client. Ensure your environment allows these headers to pass through.
+
 Set the cookie in your deployment environment using the `ROBLOX_COOKIE` variable:
 
 ```bash

--- a/src/constants/robloxHeaders.ts
+++ b/src/constants/robloxHeaders.ts
@@ -1,0 +1,5 @@
+export const ROBLOX_HEADERS = {
+  'User-Agent': 'Roblox/WinInet',
+  'Referer': 'https://www.roblox.com/',
+  'Accept': 'application/json'
+} as const;

--- a/src/lib/robloxStatus.ts
+++ b/src/lib/robloxStatus.ts
@@ -1,4 +1,5 @@
 import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../constants/bedwars';
+import { ROBLOX_HEADERS } from '../constants/robloxHeaders';
 
 interface UserPresence {
   userPresenceType: number;
@@ -26,7 +27,13 @@ const CACHE_DURATION = 60; // seconds
 const statusCache = new Map<number, UserStatus>();
 
 async function fetchJson(url: string, options: RequestInit = {}) {
-  const res = await fetch(url, options);
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      ...ROBLOX_HEADERS,
+      ...(options.headers || {})
+    }
+  });
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);
   }

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -32,6 +32,7 @@ const CACHE_DURATION = 60; // Cache for 1 minute
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY = 1000;
 import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../../src/constants/bedwars.ts';
+import { ROBLOX_HEADERS } from '../../src/constants/robloxHeaders.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
@@ -65,9 +66,8 @@ async function fetchWithTimeout(url: string, options: RequestInit = {}): Promise
       ...options,
       signal: controller.signal,
       headers: {
-        ...options.headers,
-        'User-Agent': 'Roblox/Status/Checker',
-        'Accept': 'application/json'
+        ...ROBLOX_HEADERS,
+        ...(options.headers || {})
       }
     });
     clearTimeout(id);


### PR DESCRIPTION
## Summary
- ensure presence function sets Roblox headers
- send Roblox headers from library utils
- document header usage

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841827dc0b0832dbf8b4ba793bf1364