### PR TITLE
Fix BedWars presence detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Environment Variables
 
-The `roblox-status` function uses the Roblox Presence API and requires a `.ROBLOSECURITY` cookie for detailed presence information. The cookie can be provided either via the `ROBLOX_COOKIE` environment variable or stored in the `roblox_settings` table (row with `id` set to `global`). If both are present, the table value is used.
+The `roblox-status` function uses the Roblox Presence API via RoProxy and requires a `.ROBLOSECURITY` cookie for detailed presence information. The cookie can be provided either via the `ROBLOX_COOKIE` environment variable or stored in the `roblox_settings` table (row with `id` set to `global`). If both are present, the table value is used.
 
 All Roblox API requests are sent with the headers `User-Agent: Roblox/WinInet` and `Referer: https://www.roblox.com/` to mimic the official client. Ensure your environment allows these headers to pass through.
 

--- a/src/components/RobloxStatus.tsx
+++ b/src/components/RobloxStatus.tsx
@@ -39,7 +39,7 @@ export default function RobloxStatus({ userId }: RobloxStatusProps) {
             className={status.isOnline ? 'text-green-500' : 'text-gray-400'}
           />
           <span className={status.isOnline ? 'text-green-600 dark:text-green-400' : 'text-gray-500'}>
-            {status.username} ({status.isOnline ? 'Online' : 'Offline'})
+            {status.username} ({status.isInGame ? 'In Game' : status.isOnline ? 'Online' : 'Offline'})
           </span>
         </div>
         

--- a/src/hooks/useRobloxStatus.ts
+++ b/src/hooks/useRobloxStatus.ts
@@ -4,6 +4,7 @@ import { BEDWARS_PLACE_ID, BEDWARS_UNIVERSE_ID } from '../constants/bedwars';
 
 interface RobloxStatus {
   isOnline: boolean;
+  isInGame: boolean;
   inBedwars: boolean;
   lastUpdated: number;
   username: string;
@@ -98,11 +99,14 @@ export function useRobloxStatus(userId: number) {
           if (mounted) {
             setStatus({
               isOnline: data.isOnline,
+              isInGame: data.isInGame ?? (typeof data.placeId === 'number' || typeof data.universeId === 'number'),
               inBedwars: typeof data.inBedwars === 'boolean'
                 ? data.inBedwars
-                : data.placeId === BEDWARS_PLACE_ID ||
-                  data.rootPlaceId === BEDWARS_PLACE_ID ||
-                  data.universeId === BEDWARS_UNIVERSE_ID,
+                : (data.isInGame ?? false) && (
+                    data.placeId === BEDWARS_PLACE_ID ||
+                    data.rootPlaceId === BEDWARS_PLACE_ID ||
+                    data.universeId === BEDWARS_UNIVERSE_ID
+                  ),
               lastUpdated: data.lastUpdated || Date.now(),
               username: data.username || `User ${userId}`,
               placeId: data.placeId,

--- a/src/lib/robloxStatus.test.ts
+++ b/src/lib/robloxStatus.test.ts
@@ -33,6 +33,8 @@ describe('getUserStatus', () => {
     global.fetch = fetchMock;
 
     const status = await getUserStatus(1);
+    expect(fetchMock.mock.calls[0][0]).toContain('presence.roproxy.com');
+    expect(status.isInGame).toBe(true);
     expect(status.inBedwars).toBe(true);
     expect(status.placeId).toBe(BEDWARS_PLACE_ID);
     expect(status.rootPlaceId).toBe(BEDWARS_PLACE_ID);

--- a/src/lib/robloxStatus.ts
+++ b/src/lib/robloxStatus.ts
@@ -16,6 +16,7 @@ export interface UserStatus {
   userId: number;
   username: string;
   isOnline: boolean;
+  isInGame: boolean;
   inBedwars: boolean;
   placeId: number | null;
   rootPlaceId: number | null;
@@ -40,8 +41,10 @@ async function fetchJson(url: string, options: RequestInit = {}) {
   return res.json();
 }
 
+const PRESENCE_API_URL = 'https://presence.roproxy.com/v1/presence/users';
+
 async function getUserPresence(userId: number, cookie?: string): Promise<UserPresence> {
-  const data = await fetchJson('https://presence.roblox.com/v1/presence/users', {
+  const data = await fetchJson(PRESENCE_API_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -76,10 +79,12 @@ export async function getUserStatus(userId: number, cookie?: string): Promise<Us
     userId,
     username,
     isOnline: [1, 2].includes(presence.userPresenceType),
+    isInGame: presence.userPresenceType === 2,
     inBedwars:
-      Number(presence.placeId) === BEDWARS_PLACE_ID ||
-      Number(presence.rootPlaceId) === BEDWARS_PLACE_ID ||
-      Number(presence.universeId) === BEDWARS_UNIVERSE_ID,
+      presence.userPresenceType === 2 &&
+      (Number(presence.placeId) === BEDWARS_PLACE_ID ||
+        Number(presence.rootPlaceId) === BEDWARS_PLACE_ID ||
+        Number(presence.universeId) === BEDWARS_UNIVERSE_ID),
     placeId: presence.placeId ? Number(presence.placeId) : null,
     rootPlaceId: presence.rootPlaceId ? Number(presence.rootPlaceId) : null,
     universeId: presence.universeId ? Number(presence.universeId) : null,

--- a/src/pages/PlayersPage.tsx
+++ b/src/pages/PlayersPage.tsx
@@ -49,7 +49,14 @@ export default function PlayersPage() {
                     ...acc,
                     status: {
                       isOnline: data.isOnline,
-                      inBedwars: data.inBedwars,
+                      isInGame: data.isInGame ?? false,
+                      inBedwars: typeof data.inBedwars === 'boolean'
+                        ? data.inBedwars
+                        : (data.isInGame ?? false) && (
+                            data.placeId === BEDWARS_PLACE_ID ||
+                            data.rootPlaceId === BEDWARS_PLACE_ID ||
+                            data.universeId === BEDWARS_UNIVERSE_ID
+                          ),
                       placeId: data.placeId,
                       rootPlaceId: data.rootPlaceId,
                       universeId: data.universeId,

--- a/src/types/players.ts
+++ b/src/types/players.ts
@@ -20,6 +20,7 @@ export interface PlayerAccount {
   rank?: AccountRank;
   status?: {
     isOnline: boolean;
+    isInGame: boolean;
     inBedwars: boolean;
     placeId?: number;
     rootPlaceId?: number;

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -21,6 +21,7 @@ interface UserStatus {
   userId: number;
   username: string;
   isOnline: boolean;
+  isInGame: boolean;
   inBedwars: boolean;
   placeId: number | null;
   rootPlaceId: number | null;
@@ -103,9 +104,11 @@ async function fetchWithRetry(url: string, options: RequestInit = {}, retries = 
   }
 }
 
+const PRESENCE_API_URL = 'https://presence.roproxy.com/v1/presence/users';
+
 async function getUserPresence(userId: number): Promise<UserPresence> {
   const cookie = await getRobloxCookie();
-  const response = await fetchWithRetry('https://presence.roblox.com/v1/presence/users', {
+  const response = await fetchWithRetry(PRESENCE_API_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -175,7 +178,8 @@ async function getUserStatus(userId: number): Promise<UserStatus> {
       userId,
       username,
       isOnline: presence ? [1, 2].includes(presence.userPresenceType) : false,
-      inBedwars: presence
+      isInGame: presence ? presence.userPresenceType === 2 : false,
+      inBedwars: presence && presence.userPresenceType === 2
         ? Number(presence.placeId) === BEDWARS_PLACE_ID ||
           Number(presence.rootPlaceId) === BEDWARS_PLACE_ID ||
           Number(presence.universeId) === BEDWARS_UNIVERSE_ID


### PR DESCRIPTION
## Summary
- identify users playing BedWars via RoProxy presence API
- display `In Game` status instead of `Online`
- include new `isInGame` field in presence data
- document RoProxy requirement

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx -y vitest run` *(fails to load vitest config: module not found)*


------
https://chatgpt.com/codex/tasks/task_e_6841914f1df0832d9dde509c8d8aa743