### PR TITLE
Fix bedwars status detection and show API used

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -421,9 +421,9 @@ function PlayerCard({ player, onDelete, isAdmin }: PlayerCardProps) {
                   />
                 )}
                 {(account.status?.inBedwars ||
-                  account.status?.placeId === BEDWARS_PLACE_ID ||
-                  account.status?.rootPlaceId === BEDWARS_PLACE_ID ||
-                  account.status?.universeId === BEDWARS_UNIVERSE_ID) && (
+                  Number(account.status?.placeId) === BEDWARS_PLACE_ID ||
+                  Number(account.status?.rootPlaceId) === BEDWARS_PLACE_ID ||
+                  Number(account.status?.universeId) === BEDWARS_UNIVERSE_ID) && (
                   <img
                     src={BEDWARS_ICON_URL}
                     alt="BedWars"
@@ -547,9 +547,9 @@ function PlayerCard({ player, onDelete, isAdmin }: PlayerCardProps) {
                       </div>
                     )}
                     {(account.status?.inBedwars ||
-                      account.status?.placeId === BEDWARS_PLACE_ID ||
-                      account.status?.rootPlaceId === BEDWARS_PLACE_ID ||
-                      account.status?.universeId === BEDWARS_UNIVERSE_ID) && (
+                      Number(account.status?.placeId) === BEDWARS_PLACE_ID ||
+                      Number(account.status?.rootPlaceId) === BEDWARS_PLACE_ID ||
+                      Number(account.status?.universeId) === BEDWARS_UNIVERSE_ID) && (
                       <img
                         src={BEDWARS_ICON_URL}
                         alt="BedWars"

--- a/src/components/RobloxCookiePanel.tsx
+++ b/src/components/RobloxCookiePanel.tsx
@@ -175,7 +175,14 @@ const RobloxCookiePanel: React.FC = () => {
             ) : (
               <div className="space-y-2">
                 {testResult?.presenceMethod && (
-                  <p className="text-sm">Used API: {testResult.presenceMethod}</p>
+                  <p className="text-sm">
+                    Used API:{' '}
+                    {testResult.presenceMethod === 'primary'
+                      ? 'roblox-proxy.theraccoonmolester.workers.dev'
+                      : testResult.presenceMethod === 'fallback'
+                      ? 'presence.roproxy.com'
+                      : testResult.presenceMethod}
+                  </p>
                 )}
                 <pre className="text-sm whitespace-pre-wrap break-all">
                   {JSON.stringify(testResult, null, 2)}

--- a/src/components/RobloxStatus.tsx
+++ b/src/components/RobloxStatus.tsx
@@ -44,9 +44,9 @@ export default function RobloxStatus({ userId }: RobloxStatusProps) {
         </div>
         
         {(status.inBedwars ||
-          status.placeId === BEDWARS_PLACE_ID ||
-          status.rootPlaceId === BEDWARS_PLACE_ID ||
-          status.universeId === BEDWARS_UNIVERSE_ID) && (
+          Number(status.placeId) === BEDWARS_PLACE_ID ||
+          Number(status.rootPlaceId) === BEDWARS_PLACE_ID ||
+          Number(status.universeId) === BEDWARS_UNIVERSE_ID) && (
           <div className="flex items-center gap-1 text-blue-600 dark:text-blue-400">
             <Gamepad2 size={12} />
             <span>In Bedwars</span>

--- a/src/hooks/useRobloxStatus.ts
+++ b/src/hooks/useRobloxStatus.ts
@@ -103,9 +103,9 @@ export function useRobloxStatus(userId: number) {
               inBedwars: typeof data.inBedwars === 'boolean'
                 ? data.inBedwars
                 : (data.isInGame ?? false) && (
-                    data.placeId === BEDWARS_PLACE_ID ||
-                    data.rootPlaceId === BEDWARS_PLACE_ID ||
-                    data.universeId === BEDWARS_UNIVERSE_ID
+                    Number(data.placeId) === BEDWARS_PLACE_ID ||
+                    Number(data.rootPlaceId) === BEDWARS_PLACE_ID ||
+                    Number(data.universeId) === BEDWARS_UNIVERSE_ID
                   ),
               lastUpdated: data.lastUpdated || Date.now(),
               username: data.username || `User ${userId}`,

--- a/src/pages/PlayersPage.tsx
+++ b/src/pages/PlayersPage.tsx
@@ -53,9 +53,9 @@ export default function PlayersPage() {
                       inBedwars: typeof data.inBedwars === 'boolean'
                         ? data.inBedwars
                         : (data.isInGame ?? false) && (
-                            data.placeId === BEDWARS_PLACE_ID ||
-                            data.rootPlaceId === BEDWARS_PLACE_ID ||
-                            data.universeId === BEDWARS_UNIVERSE_ID
+                            Number(data.placeId) === BEDWARS_PLACE_ID ||
+                            Number(data.rootPlaceId) === BEDWARS_PLACE_ID ||
+                            Number(data.universeId) === BEDWARS_UNIVERSE_ID
                           ),
                       placeId: data.placeId,
                       rootPlaceId: data.rootPlaceId,


### PR DESCRIPTION
## Summary
- robust check for Bedwars place IDs by coercing numeric values
- clarify which API is used when testing Roblox cookie

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac399d14832d8a3f9141ae00c773