### PR TITLE
Improve BedWars presence detection

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -420,10 +420,11 @@ function PlayerCard({ player, onDelete, isAdmin }: PlayerCardProps) {
                     title="Rank unknown"
                   />
                 )}
-                {(account.status?.inBedwars ||
-                  Number(account.status?.placeId) === BEDWARS_PLACE_ID ||
-                  Number(account.status?.rootPlaceId) === BEDWARS_PLACE_ID ||
-                  Number(account.status?.universeId) === BEDWARS_UNIVERSE_ID) && (
+                {account.status?.isInGame &&
+                  (account.status?.inBedwars ||
+                    Number(account.status?.placeId) === BEDWARS_PLACE_ID ||
+                    Number(account.status?.rootPlaceId) === BEDWARS_PLACE_ID ||
+                    Number(account.status?.universeId) === BEDWARS_UNIVERSE_ID) && (
                   <img
                     src={BEDWARS_ICON_URL}
                     alt="BedWars"
@@ -546,10 +547,11 @@ function PlayerCard({ player, onDelete, isAdmin }: PlayerCardProps) {
                         <span className="text-sm">Rank unknown</span>
                       </div>
                     )}
-                    {(account.status?.inBedwars ||
-                      Number(account.status?.placeId) === BEDWARS_PLACE_ID ||
-                      Number(account.status?.rootPlaceId) === BEDWARS_PLACE_ID ||
-                      Number(account.status?.universeId) === BEDWARS_UNIVERSE_ID) && (
+                    {account.status?.isInGame &&
+                      (account.status?.inBedwars ||
+                        Number(account.status?.placeId) === BEDWARS_PLACE_ID ||
+                        Number(account.status?.rootPlaceId) === BEDWARS_PLACE_ID ||
+                        Number(account.status?.universeId) === BEDWARS_UNIVERSE_ID) && (
                       <img
                         src={BEDWARS_ICON_URL}
                         alt="BedWars"

--- a/src/components/RobloxCookiePanel.tsx
+++ b/src/components/RobloxCookiePanel.tsx
@@ -176,12 +176,18 @@ const RobloxCookiePanel: React.FC = () => {
               <div className="space-y-2">
                 {testResult?.presenceMethod && (
                   <p className="text-sm">
-                    Used API:{' '}
-                    {testResult.presenceMethod === 'primary'
-                      ? 'roblox-proxy.theraccoonmolester.workers.dev'
-                      : testResult.presenceMethod === 'fallback'
-                      ? 'presence.roproxy.com'
-                      : testResult.presenceMethod}
+                    <span
+                      className="underline decoration-dotted cursor-help"
+                      title={`Used API: ${
+                        testResult.presenceMethod === 'primary'
+                          ? 'roblox-proxy.theraccoonmolester.workers.dev'
+                          : testResult.presenceMethod === 'fallback'
+                          ? 'presence.roproxy.com'
+                          : 'presence.roblox.com'
+                      }`}
+                    >
+                      API Method: {testResult.presenceMethod}
+                    </span>
                   </p>
                 )}
                 <pre className="text-sm whitespace-pre-wrap break-all">

--- a/src/lib/robloxStatus.test.ts
+++ b/src/lib/robloxStatus.test.ts
@@ -36,6 +36,7 @@ describe('getUserStatus', () => {
     expect(fetchMock.mock.calls[0][0]).toContain('roblox-proxy.theraccoonmolester.workers.dev');
     expect(status.isInGame).toBe(true);
     expect(status.inBedwars).toBe(true);
+    expect(status.presenceMethod).toBe('primary');
     expect(status.placeId).toBe(BEDWARS_PLACE_ID);
     expect(status.rootPlaceId).toBe(BEDWARS_PLACE_ID);
     expect(status.universeId).toBe(BEDWARS_UNIVERSE_ID);

--- a/src/lib/robloxStatus.ts
+++ b/src/lib/robloxStatus.ts
@@ -14,7 +14,7 @@ interface UserPresence {
 
 interface PresenceResult {
   presence: UserPresence;
-  method: 'primary' | 'fallback';
+  method: 'primary' | 'fallback' | 'direct';
 }
 
 export interface UserStatus {
@@ -27,7 +27,7 @@ export interface UserStatus {
   rootPlaceId: number | null;
   universeId: number | null;
   lastUpdated: number;
-  presenceMethod: 'primary' | 'fallback';
+  presenceMethod: 'primary' | 'fallback' | 'direct';
 }
 
 const CACHE_DURATION = 60; // seconds
@@ -51,6 +51,7 @@ const PRESENCE_API_PRIMARY =
   'https://roblox-proxy.theraccoonmolester.workers.dev/presence/v1/presence/users';
 const PRESENCE_API_FALLBACK =
   'https://presence.roproxy.com/v1/presence/users';
+const PRESENCE_API_DIRECT = 'https://presence.roblox.com/v1/presence/users';
 
 async function getUserPresence(userId: number, cookie?: string): Promise<PresenceResult> {
   const options = {
@@ -62,9 +63,10 @@ async function getUserPresence(userId: number, cookie?: string): Promise<Presenc
     body: JSON.stringify({ userIds: [userId] })
   } as const;
 
-  const urls: [string, 'primary' | 'fallback'][] = [
+  const urls: [string, 'primary' | 'fallback' | 'direct'][] = [
     [PRESENCE_API_PRIMARY, 'primary'],
-    [PRESENCE_API_FALLBACK, 'fallback']
+    [PRESENCE_API_FALLBACK, 'fallback'],
+    [PRESENCE_API_DIRECT, 'direct']
   ];
 
   for (const [url, method] of urls) {

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -19,7 +19,7 @@ interface UserPresence {
 
 interface PresenceResult {
   presence: UserPresence;
-  method: 'primary' | 'fallback';
+  method: 'primary' | 'fallback' | 'direct';
 }
 
 interface UserStatus {
@@ -32,7 +32,7 @@ interface UserStatus {
   rootPlaceId: number | null;
   universeId: number | null;
   lastUpdated: number;
-  presenceMethod: 'primary' | 'fallback';
+  presenceMethod: 'primary' | 'fallback' | 'direct';
 }
 
 const CACHE_DURATION = 60; // Cache for 1 minute
@@ -113,6 +113,7 @@ async function fetchWithRetry(url: string, options: RequestInit = {}, retries = 
 const PRESENCE_API_PRIMARY =
   'https://roblox-proxy.theraccoonmolester.workers.dev/presence/v1/presence/users';
 const PRESENCE_API_FALLBACK = 'https://presence.roproxy.com/v1/presence/users';
+const PRESENCE_API_DIRECT = 'https://presence.roblox.com/v1/presence/users';
 
 async function getUserPresence(userId: number): Promise<PresenceResult> {
   const cookie = await getRobloxCookie();
@@ -125,9 +126,10 @@ async function getUserPresence(userId: number): Promise<PresenceResult> {
     body: JSON.stringify({ userIds: [userId] })
   } as const;
 
-  const urls: [string, 'primary' | 'fallback'][] = [
+  const urls: [string, 'primary' | 'fallback' | 'direct'][] = [
     [PRESENCE_API_PRIMARY, 'primary'],
-    [PRESENCE_API_FALLBACK, 'fallback']
+    [PRESENCE_API_FALLBACK, 'fallback'],
+    [PRESENCE_API_DIRECT, 'direct']
   ];
 
   for (const [url, method] of urls) {


### PR DESCRIPTION
## Summary
- enhance presence status API to try a direct Roblox API third
- surface method in results as `primary`, `fallback`, or `direct`
- show proxy details in Roblox cookie test with a tooltip
- only show BedWars icon when the player is in game

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68421a412670832db5be5f6dea90ea15