### PR TITLE
Improve cookie debug and presence logging

### DIFF
--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -161,12 +161,18 @@ async function getUserPresence(
   const attemptLog: PresenceAttempt[] = [];
 
   const cookieIncluded = !!cookie;
+  if (!cookieIncluded) {
+    console.warn('No .ROBLOSECURITY cookie supplied for presence request');
+  }
 
   for (const [url, method] of urls) {
     try {
       const response = await fetchWithRetry(url, options);
       const data = await response.json();
       if (data.userPresences?.[0]) {
+        if (method !== 'primary') {
+          console.warn(`Presence API fallback method used: ${method}`);
+        }
         attemptLog.push({
           method,
           success: true,


### PR DESCRIPTION
## Summary
- return full error in `verify-cookie` and save cookie even on failure
- show verification errors in admin panel
- display which presence proxy was used and if cookie applied
- log when presence API calls lack cookie or use fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68437e8129cc832da40d5e896b99d629