### PR TITLE
Fix presence cookie header usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ The `presenceMethod` indicates which API was used (`primary` for
 `roblox-proxy`, `fallback` for RoProxy and `direct` for Roblox). All methods
 still require a valid `.ROBLOSECURITY` cookie in order for the Presence API to
 return detailed information such as `placeId` and `universeId`.
+When invoking the function, the logs will now state whether a cookie was
+received and applied. Look for messages like `Request included cookie: true` to
+confirm the header was sent.

--- a/src/lib/robloxStatus.ts
+++ b/src/lib/robloxStatus.ts
@@ -75,10 +75,11 @@ async function getUserPresence(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...(cookie ? { Cookie: '.ROBLOSECURITY=' + cookie } : {})
+      ...(cookie ? { cookie: '.ROBLOSECURITY=' + cookie } : {})
     },
     body: JSON.stringify({ userIds: [userId] })
   } as const;
+  console.log('Presence request using cookie:', !!cookie);
 
   const urlMap = {
     primary: PRESENCE_API_PRIMARY,

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -133,11 +133,16 @@ async function getUserPresence(
   supabase: SupabaseClient
 ): Promise<PresenceResult> {
   const cookie = cookieOverride || (await getRobloxCookie(supabase));
+  if (cookie) {
+    console.log('Using ROBLOX_COOKIE for presence request');
+  } else {
+    console.warn('No .ROBLOSECURITY cookie supplied for presence request');
+  }
   const options = {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...(cookie ? { 'Cookie': '.ROBLOSECURITY=' + cookie } : {})
+      ...(cookie ? { 'cookie': '.ROBLOSECURITY=' + cookie } : {})
     },
     body: JSON.stringify({ userIds: [userId] })
   } as const;
@@ -159,9 +164,6 @@ async function getUserPresence(
   const attemptLog: PresenceAttempt[] = [];
 
   const cookieIncluded = !!cookie;
-  if (!cookieIncluded) {
-    console.warn('No .ROBLOSECURITY cookie supplied for presence request');
-  }
 
   for (const [url, method] of urls) {
     try {
@@ -334,6 +336,7 @@ if (import.meta.main) {
     const cookieHeader = req.headers.get('cookie') || '';
     const cookieMatch = cookieHeader.match(/\.ROBLOSECURITY=([^;]+)/);
     const requestCookie = cookieMatch ? cookieMatch[1] : undefined;
+    console.log('Request included cookie:', !!requestCookie);
 
     const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
     const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';


### PR DESCRIPTION
## Summary
- include `.ROBLOSECURITY` cookie header in presence requests
- log whether cookie was provided in Supabase function and client library
- document new log messages in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684afd6c00f8832da9c46083518d7dbe