### PR TITLE
Add debug logs for Roblox cookie handling

### DIFF
--- a/src/components/RobloxCookiePanel.tsx
+++ b/src/components/RobloxCookiePanel.tsx
@@ -110,6 +110,7 @@ const RobloxCookiePanel: React.FC = () => {
       const methodQuery = testMethod === 'auto' ? '' : `&method=${testMethod}`;
       const path = `roblox-status?userId=${TEST_USER_ID}${methodQuery}`;
       const trimmedCookie = cookie.trim();
+      console.log('Sending cookie:', cookie);
       const { data, error } = await supabase.functions.invoke(path, {
         body: trimmedCookie ? { cookie: trimmedCookie } : {}
       });

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -169,6 +169,8 @@ async function getUserPresence(
     try {
       const response = await fetchWithRetry(url, options);
       const data = await response.json();
+      console.log('Roblox fetch headers:', options.headers);
+      console.log('Roblox response data:', data);
       if (data.userPresences?.[0]) {
         if (method !== 'primary') {
           console.warn(`Presence API fallback method used: ${method}`);
@@ -334,15 +336,19 @@ if (import.meta.main) {
     }
 
     let requestCookie: string | undefined;
+    let reqBody: any = {};
 
     try {
-      const { cookie } = await req.json();
+      reqBody = await req.json();
+      const { cookie } = reqBody;
       if (cookie && typeof cookie === 'string') {
         requestCookie = cookie.trim();
       }
     } catch {
+      reqBody = {};
       // no JSON body or invalid JSON
     }
+    console.log('reqBody.cookie.length', reqBody.cookie ? reqBody.cookie.length : 0);
 
     if (!requestCookie) {
       const cookieHeader = req.headers.get('cookie') || '';


### PR DESCRIPTION
## Summary
- log cookie value when invoking presence test
- log cookie length and fetch details in `roblox-status` function

## Testing
- `npm install` *(fails: Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684b1bfd118c832da2882dfec8ef944c