### PR TITLE
Fix cookie handling in presence test

### DIFF
--- a/src/components/RobloxCookiePanel.tsx
+++ b/src/components/RobloxCookiePanel.tsx
@@ -107,12 +107,12 @@ const RobloxCookiePanel: React.FC = () => {
     setTestError(null);
     const TEST_USER_ID = 77146135;
     try {
-      const methodQuery = testMethod === 'auto' ? '' : `&method=${testMethod}`;
-      const path = `roblox-status?userId=${TEST_USER_ID}${methodQuery}`;
+      const path =
+        testMethod === 'auto' ? 'roblox-status' : `roblox-status?method=${testMethod}`;
       const trimmedCookie = cookie.trim();
-      console.log('Sending cookie:', cookie);
+      console.log('Sending cookie:', trimmedCookie);
       const { data, error } = await supabase.functions.invoke(path, {
-        body: trimmedCookie ? { cookie: trimmedCookie } : {}
+        body: { userId: TEST_USER_ID, cookie: trimmedCookie }
       });
       if (error) throw error;
       setTestResult(data as any);


### PR DESCRIPTION
## Summary
- ensure test call sends userId and cookie body to `roblox-status` function
- log sent cookie to help with debugging
- update edge function to read userId from body and log cookie
- send ROBLOX cookie via `Cookie` header and include custom UA

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684bfc2f3278832dbff43c2c5a405788