### PR TITLE
Fix cookie loading for Roblox status

### DIFF
--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -326,14 +326,27 @@ if (import.meta.main) {
     }
 
     const trimmed = typeof cookie === 'string' ? cookie.trim() : '';
-    console.log('Cookie length:', trimmed.length);
+    let finalCookie = trimmed;
+
+    if (finalCookie.length === 0) {
+      const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+      const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+      if (supabaseUrl && serviceKey) {
+        const supabase = createClient(supabaseUrl, serviceKey);
+        finalCookie = await getRobloxCookie(supabase);
+      } else {
+        finalCookie = (Deno.env.get('ROBLOX_COOKIE') || '').trim();
+      }
+    }
+
+    console.log('Cookie length:', finalCookie.length);
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'User-Agent': 'Roblox/WinInet'
     };
-    if (trimmed.length > 0) {
-      headers.Cookie = `.ROBLOSECURITY=${trimmed}`;
+    if (finalCookie.length > 0) {
+      headers.Cookie = `.ROBLOSECURITY=${finalCookie}`;
     }
     console.log('Fetch headers:', headers);
 


### PR DESCRIPTION
## Summary
- load a stored Roblox cookie using `getRobloxCookie` when the request doesn't include one

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5b6c1090832db1317462449dccba