### PR TITLE
Fix typing for roblox-status function

### DIFF
--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -1,3 +1,4 @@
+/// <reference lib="deno.ns" />
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Summary
- ensure `roblox-status` function has Deno namespace types

## Testing
- `npx supabase functions serve supabase/functions/roblox-status` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684ce8fc99cc832d817e9c345508e0fb