### PR TITLE
Add presence to user status

### DIFF
--- a/src/lib/robloxStatus.test.ts
+++ b/src/lib/robloxStatus.test.ts
@@ -45,5 +45,8 @@ describe('getUserStatus', () => {
       { method: 'primary', success: true, cookie: false }
     ]);
     expect(status.cookieProvided).toBe(false);
+    expect(status.presence).toEqual(
+      expect.objectContaining({ userPresenceType: 2 })
+    );
   });
 });

--- a/src/lib/robloxStatus.ts
+++ b/src/lib/robloxStatus.ts
@@ -41,6 +41,7 @@ export interface UserStatus {
   presenceMethod: 'primary' | 'fallback' | 'direct';
   attemptLog: PresenceAttempt[];
   cookieProvided: boolean;
+  presence?: UserPresence;
 }
 
 const CACHE_DURATION = 60; // seconds
@@ -170,6 +171,7 @@ export async function getUserStatus(
     attemptLog,
     cookieProvided
   };
-  statusCache.set(cacheKey, status);
-  return status;
+  const fullStatus: UserStatus = { ...status, presence };
+  statusCache.set(cacheKey, fullStatus);
+  return fullStatus;
 }

--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -49,6 +49,7 @@ interface UserStatus {
   presenceMethod: 'primary' | 'fallback' | 'direct';
   attemptLog: PresenceAttempt[];
   cookieProvided: boolean;
+  presence?: UserPresence;
 }
 
 const CACHE_DURATION = 60; // Cache for 1 minute
@@ -307,8 +308,9 @@ async function getUserStatus(
     };
 
     // Update cache
-    statusCache.set(cacheKey, status);
-    return { ...status, presence };
+    const fullStatus: UserStatus = { ...status, presence };
+    statusCache.set(cacheKey, fullStatus);
+    return fullStatus;
   } catch (error) {
     console.error('Error in getUserStatus:', error);
     throw error;


### PR DESCRIPTION
## Summary
- include optional presence field in user status type
- return presence data in roblox status helpers
- test for presence property

## Testing
- `npx vitest` *(fails: Need to install the following packages: vitest@3.2.3)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d5501cb1c832d858b2e5fc15073dc