### PR TITLE
Check Supabase env in roblox-status

### DIFF
--- a/supabase/functions/roblox-status/index.ts
+++ b/supabase/functions/roblox-status/index.ts
@@ -342,6 +342,18 @@ async function getUserStatus(
 
       const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
       const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+      if (!supabaseUrl || !serviceKey) {
+        console.error(
+          'Supabase environment variables missing: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY'
+        );
+        return new Response(
+          JSON.stringify({ error: 'Missing Supabase configuration' }),
+          {
+            status: 500,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+          }
+        );
+      }
       const supabase = createClient(supabaseUrl, serviceKey);
 
       const { presence } = await getUserPresence(


### PR DESCRIPTION
## Summary
- log an error and return 500 in `roblox-status` function when `SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` are missing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d590c3a18832dbc80ebfac9b730de